### PR TITLE
Changes required in gl-plot3d module for implementing break lines, sub & superscripts as well as bold & italic styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#0ffa622777a96a8cb25894ed67be9f254ca123ad",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#0ffa622777a96a8cb25894ed67be9f254ca123ad",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#2302e3e33986e3bf34222b92d6091ad8bd021a0d",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#2302e3e33986e3bf34222b92d6091ad8bd021a0d",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
-          "from": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
+          "version": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
+          "from": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,9 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.3.2.tgz",
-      "integrity": "sha512-djAEyX7pz1C9CICos300JNAbdsFHCb2oWXAg1d/Zge+8VgUg+QayfQemHhVv8JVbcoWulnvZp8K+yQEBnCEhPw==",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#392e1071c9a79557e6c539c531875ef7f102e783",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#392e1071c9a79557e6c539c531875ef7f102e783",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -841,7 +840,22 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "^3.0.0"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11"
+      },
+      "dependencies": {
+        "vectorize-text": {
+          "version": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
+          "from": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
+          "requires": {
+            "cdt2d": "^1.0.0",
+            "clean-pslg": "^1.1.0",
+            "ndarray": "^1.0.11",
+            "planar-graph-to-polyline": "^1.0.0",
+            "simplify-planar-graph": "^2.0.1",
+            "surface-nets": "^1.0.0",
+            "triangulate-polyline": "^1.0.0"
+          }
+        }
       }
     },
     "gl-buffer": {
@@ -2410,6 +2424,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.0.2.tgz",
       "integrity": "sha1-BasWMOQJ83eWTiuSBbLVWakvYNg=",
+      "dev": true,
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#3ed657511d7bb3fa3e5dffc03f620e6d25ee1c04",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#3ed657511d7bb3fa3e5dffc03f620e6d25ee1c04",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#3d724bea5f17da5feca732a0d6019ed9ef13de23",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#3d724bea5f17da5feca732a0d6019ed9ef13de23",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
-          "from": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
+          "version": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
+          "from": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#3d724bea5f17da5feca732a0d6019ed9ef13de23",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#3d724bea5f17da5feca732a0d6019ed9ef13de23",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#39295551263eec27364c68c9e7289153278d39a4",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#39295551263eec27364c68c9e7289153278d39a4",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
-          "from": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
+          "version": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
+          "from": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#fe2cd449ef83fe58dbe4508c2e4e34a10825223a",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#fe2cd449ef83fe58dbe4508c2e4e34a10825223a",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#af3d99d2ca04959c53fea509543389e1df0a5c0e",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#af3d99d2ca04959c53fea509543389e1df0a5c0e",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
-          "from": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
+          "version": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652",
+          "from": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#a449c54c5a39a21735804de722cc1374f008c3df",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#a449c54c5a39a21735804de722cc1374f008c3df",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#82a1e8eeadb3feef7f5c8eafd569939dcc1f5e75",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#82a1e8eeadb3feef7f5c8eafd569939dcc1f5e75",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
-          "from": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
+          "version": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
+          "from": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#f85b846dacd7b734aae2d64280b4e9e3079bfa85",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#f85b846dacd7b734aae2d64280b4e9e3079bfa85",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#a449c54c5a39a21735804de722cc1374f008c3df",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#a449c54c5a39a21735804de722cc1374f008c3df",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
-          "from": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
+          "version": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
+          "from": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#392e1071c9a79557e6c539c531875ef7f102e783",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#392e1071c9a79557e6c539c531875ef7f102e783",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#fe2cd449ef83fe58dbe4508c2e4e34a10825223a",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#fe2cd449ef83fe58dbe4508c2e4e34a10825223a",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
-          "from": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
+          "version": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
+          "from": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,9 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#226ce53986dd7211fcfbe05354cfb53199f8bb1e",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#226ce53986dd7211fcfbe05354cfb53199f8bb1e",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.4.0.tgz",
+      "integrity": "sha512-aakup65ywK7Bo0k/2IAq8AdvtZYHJANskePJpElcmuC1vm0l+4sRKmXevdR9AYBDNh5KEULFSnTe9RHVPvBtxQ==",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +841,13 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0"
+        "vectorize-text": "^3.2.0"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
-          "from": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.0.tgz",
+          "integrity": "sha512-N3eldFPkXY7mVK1aBuKPdQKYerBSPEAf+4Tl6DGdnVb1MZ8buD9SKv5TUCyRCEe5KblC56MoJcmf0I/IyGjOGQ==",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#af3d99d2ca04959c53fea509543389e1df0a5c0e",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#af3d99d2ca04959c53fea509543389e1df0a5c0e",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#0373535b281409b0f748759e8e613a3f7332f82d",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#0373535b281409b0f748759e8e613a3f7332f82d",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,18 +840,19 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652",
-          "from": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652",
+          "version": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
+          "from": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",
             "ndarray": "^1.0.11",
             "planar-graph-to-polyline": "^1.0.0",
             "simplify-planar-graph": "^2.0.1",
+            "superscript-text": "^1.0.0",
             "surface-nets": "^1.0.0",
             "triangulate-polyline": "^1.0.0"
           }
@@ -2253,6 +2254,11 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "superscript-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
     },
     "surface-nets": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#82a1e8eeadb3feef7f5c8eafd569939dcc1f5e75",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#82a1e8eeadb3feef7f5c8eafd569939dcc1f5e75",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#5d6232ea0187e9081cd3a55eed535ce7e670a479",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#5d6232ea0187e9081cd3a55eed535ce7e670a479",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
-          "from": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
+          "version": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
+          "from": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#39295551263eec27364c68c9e7289153278d39a4",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#39295551263eec27364c68c9e7289153278d39a4",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#fdfdaef6bfdd5623ef062a4745a57229df6cddb4",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#fdfdaef6bfdd5623ef062a4745a57229df6cddb4",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
-          "from": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
+          "version": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
+          "from": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#5d6232ea0187e9081cd3a55eed535ce7e670a479",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#5d6232ea0187e9081cd3a55eed535ce7e670a479",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#226ce53986dd7211fcfbe05354cfb53199f8bb1e",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#226ce53986dd7211fcfbe05354cfb53199f8bb1e",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
-          "from": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
+          "version": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
+          "from": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#2302e3e33986e3bf34222b92d6091ad8bd021a0d",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#2302e3e33986e3bf34222b92d6091ad8bd021a0d",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#3ed657511d7bb3fa3e5dffc03f620e6d25ee1c04",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#3ed657511d7bb3fa3e5dffc03f620e6d25ee1c04",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,12 +840,12 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
-          "from": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
+          "version": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
+          "from": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#fdfdaef6bfdd5623ef062a4745a57229df6cddb4",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#fdfdaef6bfdd5623ef062a4745a57229df6cddb4",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#f85b846dacd7b734aae2d64280b4e9e3079bfa85",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#f85b846dacd7b734aae2d64280b4e9e3079bfa85",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,8 +825,8 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "git://github.com/gl-vis/gl-axes3d.git#0373535b281409b0f748759e8e613a3f7332f82d",
-      "from": "git://github.com/gl-vis/gl-axes3d.git#0373535b281409b0f748759e8e613a3f7332f82d",
+      "version": "git://github.com/gl-vis/gl-axes3d.git#0ffa622777a96a8cb25894ed67be9f254ca123ad",
+      "from": "git://github.com/gl-vis/gl-axes3d.git#0ffa622777a96a8cb25894ed67be9f254ca123ad",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0",
@@ -840,19 +840,18 @@
         "glslify": "^6.1.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396"
+        "vectorize-text": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86"
       },
       "dependencies": {
         "vectorize-text": {
-          "version": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
-          "from": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
+          "version": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
+          "from": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
           "requires": {
             "cdt2d": "^1.0.0",
             "clean-pslg": "^1.1.0",
             "ndarray": "^1.0.11",
             "planar-graph-to-polyline": "^1.0.0",
             "simplify-planar-graph": "^2.0.1",
-            "superscript-text": "^1.0.0",
             "surface-nets": "^1.0.0",
             "triangulate-polyline": "^1.0.0"
           }
@@ -2254,11 +2253,6 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "superscript-text": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
-      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
     },
     "surface-nets": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#39295551263eec27364c68c9e7289153278d39a4",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#fdfdaef6bfdd5623ef062a4745a57229df6cddb4",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#0ffa622777a96a8cb25894ed67be9f254ca123ad",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#2302e3e33986e3bf34222b92d6091ad8bd021a0d",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#af3d99d2ca04959c53fea509543389e1df0a5c0e",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#0373535b281409b0f748759e8e613a3f7332f82d",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#f85b846dacd7b734aae2d64280b4e9e3079bfa85",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#a449c54c5a39a21735804de722cc1374f008c3df",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#392e1071c9a79557e6c539c531875ef7f102e783",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#fe2cd449ef83fe58dbe4508c2e4e34a10825223a",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#3ed657511d7bb3fa3e5dffc03f620e6d25ee1c04",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#3d724bea5f17da5feca732a0d6019ed9ef13de23",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#2302e3e33986e3bf34222b92d6091ad8bd021a0d",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#3ed657511d7bb3fa3e5dffc03f620e6d25ee1c04",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#82a1e8eeadb3feef7f5c8eafd569939dcc1f5e75",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#5d6232ea0187e9081cd3a55eed535ce7e670a479",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#a449c54c5a39a21735804de722cc1374f008c3df",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#82a1e8eeadb3feef7f5c8eafd569939dcc1f5e75",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#0373535b281409b0f748759e8e613a3f7332f82d",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#0ffa622777a96a8cb25894ed67be9f254ca123ad",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#fdfdaef6bfdd5623ef062a4745a57229df6cddb4",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#f85b846dacd7b734aae2d64280b4e9e3079bfa85",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "^1.3.2",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#392e1071c9a79557e6c539c531875ef7f102e783",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#3d724bea5f17da5feca732a0d6019ed9ef13de23",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#39295551263eec27364c68c9e7289153278d39a4",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#5d6232ea0187e9081cd3a55eed535ce7e670a479",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#226ce53986dd7211fcfbe05354cfb53199f8bb1e",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#fe2cd449ef83fe58dbe4508c2e4e34a10825223a",
+    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#af3d99d2ca04959c53fea509543389e1df0a5c0e",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "3d-view-controls": "^2.2.0",
     "a-big-triangle": "^1.0.0",
-    "gl-axes3d": "git://github.com/gl-vis/gl-axes3d.git#226ce53986dd7211fcfbe05354cfb53199f8bb1e",
+    "gl-axes3d": "^1.4.0",
     "gl-fbo": "^2.0.3",
     "gl-mat4": "^1.1.2",
     "gl-select-static": "^2.0.2",


### PR DESCRIPTION
This PR is making use of the latest options in `vectorize-text` that enables tags namely < b > < i > < sup > < sub> and < br > within webGL texts.
Please also refer to [Plotly PR 3207](https://github.com/plotly/plotly.js/pull/3207) for more information.
@etpinard 