### PR TITLE
revise rendering pipeline of scenes with transparent objects

### DIFF
--- a/scene.js
+++ b/scene.js
@@ -700,9 +700,7 @@ function createScene(options) {
     gl.disable(gl.CULL_FACE)  //most visualization surfaces are 2 sided
 
     //Render opaque pass
-    var hasTransparent = false
     if(axes.enable) {
-      hasTransparent = hasTransparent || axes.isTransparent()
       axes.draw(cameraParams)
     }
     spikes.axes = axes
@@ -711,7 +709,7 @@ function createScene(options) {
     }
 
     gl.disable(gl.CULL_FACE)  //most visualization surfaces are 2 sided
-
+    var hasTransparent = false
     for(var i=0; i<numObjs; ++i) {
       var obj = objects[i]
       obj.axes = axes
@@ -734,9 +732,6 @@ function createScene(options) {
       gl.depthFunc(gl.LESS)
 
       //Render forward facing objects
-      if(axes.enable && axes.isTransparent()) {
-        axes.drawTransparent(cameraParams)
-      }
       for(var i=0; i<numObjs; ++i) {
         var obj = objects[i]
         if(obj.isOpaque && obj.isOpaque()) {
@@ -745,17 +740,17 @@ function createScene(options) {
       }
 
       //Render transparent pass
+      gl.enable(gl.DEPTH_TEST)
       gl.enable(gl.BLEND)
-      gl.blendEquation(gl.FUNC_ADD)
-      gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
+
       gl.colorMask(true, true, true, true)
-      gl.depthMask(false)
       gl.clearColor(0,0,0,0)
       gl.clear(gl.COLOR_BUFFER_BIT)
 
-      if(axes.isTransparent()) {
-        axes.drawTransparent(cameraParams)
-      }
+      gl.depthMask(false)
+
+      gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD)
+      gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
 
       for(var i=0; i<numObjs; ++i) {
         var obj = objects[i]
@@ -768,8 +763,11 @@ function createScene(options) {
       gl.bindFramebuffer(gl.FRAMEBUFFER, null)
 
       //Draw composite pass
+      gl.enable(gl.BLEND)
+      gl.blendEquation(gl.FUNC_ADD)
       gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
       gl.disable(gl.DEPTH_TEST)
+
       accumShader.bind()
       accumBuffer.color[0].bind(0)
       accumShader.uniforms.accumBuffer = 0

--- a/scene.js
+++ b/scene.js
@@ -742,19 +742,25 @@ function createScene(options) {
       //Render transparent pass
       gl.enable(gl.DEPTH_TEST)
       gl.enable(gl.BLEND)
+      gl.cullFace(gl.FRONT)
 
       gl.colorMask(true, true, true, true)
       gl.clearColor(0,0,0,0)
       gl.clear(gl.COLOR_BUFFER_BIT)
 
-      gl.depthMask(false)
-
-      gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD)
-      gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
-
       for(var i=0; i<numObjs; ++i) {
         var obj = objects[i]
         if(obj.isTransparent && obj.isTransparent()) {
+          var traceType = obj._trace.data.type
+          if(traceType === 'scatter3d' || traceType === 'cone') {
+            gl.depthMask(true)
+            gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
+            gl.disable(gl.CULL_FACE)
+          } else {
+            gl.depthMask(false)
+            gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
+            gl.enable(gl.CULL_FACE)
+          }
           obj.drawTransparent(cameraParams)
         }
       }

--- a/scene.js
+++ b/scene.js
@@ -742,7 +742,6 @@ function createScene(options) {
       //Render transparent pass
       gl.enable(gl.DEPTH_TEST)
       gl.enable(gl.BLEND)
-      gl.cullFace(gl.FRONT)
 
       gl.colorMask(true, true, true, true)
       gl.clearColor(0,0,0,0)
@@ -751,15 +750,13 @@ function createScene(options) {
       for(var i=0; i<numObjs; ++i) {
         var obj = objects[i]
         if(obj.isTransparent && obj.isTransparent()) {
-          var traceType = obj._trace.data.type
-          if(traceType === 'scatter3d' || traceType === 'cone') {
+          var traceData = (obj._trace || {}).data || {}
+          if(traceData.type === 'cone3d' || (traceData.type === 'scatter3d' && traceData.surfaceaxis === -1)) {
             gl.depthMask(true)
             gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
-            gl.disable(gl.CULL_FACE)
           } else {
             gl.depthMask(false)
             gl.blendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
-            gl.enable(gl.CULL_FACE)
           }
           obj.drawTransparent(cameraParams)
         }


### PR DESCRIPTION
- remove unnecessary calls to axes draw
- separate colour and alpha blending
- found an algorithm that works for point clouds, surfaces as well as volume rendering

See https://github.com/plotly/plotly.js/pull/4234 for more info.

cc: @etpinard 