### PR TITLE
Disable premultipliedAlpha on Firefox

### DIFF
--- a/scene.js
+++ b/scene.js
@@ -81,7 +81,7 @@ function createScene(options) {
   if(!gl) {
     gl = getContext(canvas,
       options.glOptions || {
-        premultipliedAlpha: true,
+        premultipliedAlpha: !navigator.userAgent.search('Firefox'),
         antialias: true,
         preserveDrawingBuffer: isMobile
       })


### PR DESCRIPTION
Please refer to https://github.com/plotly/plotly.js/pull/4280 for more info.

cc: @etpinard 