### PR TITLE
move orthographic scroll zoom from the gl-plot3d scene to plotly scene

### DIFF
--- a/scene.js
+++ b/scene.js
@@ -8,7 +8,6 @@ var createSelect = require('gl-select-static')
 var createFBO    = require('gl-fbo')
 var drawTriangle = require('a-big-triangle')
 var mouseChange  = require('mouse-change')
-var mouseWheel   = require('mouse-wheel')
 var perspective  = require('gl-mat4/perspective')
 var ortho        = require('gl-mat4/ortho')
 var createShader = require('./lib/shader')
@@ -338,21 +337,6 @@ function createScene(options) {
     spikes = null
     objects = []
   }
-
-  scene.wheelListener = mouseWheel(canvas, function(dx, dy) {
-    // TODO remove now that we can disable scroll via scrollZoom?
-    if(camera.keyBindingMode === false) return
-    if(!camera.enableWheel) return
-
-    if(camera._ortho) {
-      var s = (dx > dy) ? 1.1 : 1.0 / 1.1
-
-      scene.aspect[0] *= s
-      scene.aspect[1] *= s
-      scene.aspect[2] *= s
-      scene.redraw()
-    }
-  }, true)
 
   //Update mouse position
   scene._mouseRotating = false

--- a/scene.js
+++ b/scene.js
@@ -186,7 +186,21 @@ function createScene(options) {
     cameraParams: cameraParams,
     oncontextloss: null,
     mouseListener: null,
-    _stopped: false
+    _stopped: false,
+
+    getAspectratio: function() {
+      return {
+        x: this.aspect[0],
+        y: this.aspect[1],
+        z: this.aspect[2]
+      }
+    },
+
+    setAspectratio: function(aspectratio) {
+      this.aspect[0] = aspectratio.x
+      this.aspect[1] = aspectratio.y
+      this.aspect[2] = aspectratio.z
+    }
   }
 
   var pickShape = [ (gl.drawingBufferWidth/scene.pixelRatio)|0, (gl.drawingBufferHeight/scene.pixelRatio)|0 ]


### PR DESCRIPTION
The function which was added to make scroll zoom work on `plotly.js` graphs now moved to plotly.js scene. One could simply add a similar listener after the creation of scene.  
Please refer to https://github.com/plotly/plotly.js/pull/4292 for more info.

In addition, this PR adds getter and setter functions for reading and manipulating scene's aspect-ratio values.
@etpinard 