### PR TITLE
Correct orthographic hover after scroll zoom | gl-plot3d

### DIFF
--- a/scene.js
+++ b/scene.js
@@ -204,6 +204,7 @@ function createScene(options) {
       this.aspect[0] = aspectratio.x
       this.aspect[1] = aspectratio.y
       this.aspect[2] = aspectratio.z
+      pickDirty = true
     },
 
     setBounds: function(axisIndex, range) {


### PR DESCRIPTION
Forces redrawing pick layer after reset scene aspect ratio
see plotly issue https://github.com/plotly/plotly.js/issues/4514
cc: @etpinard 