### PR TITLE
fix gl3d hover on mobile and tablet devices

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -190,23 +190,17 @@ function createCamera(element, options) {
       var xy = mouseOffset(ev.changedTouches[0], element)
       handleInteraction(0, xy[0], xy[1], camera._lastMods)
       handleInteraction(1, xy[0], xy[1], camera._lastMods)
-
-      ev.preventDefault()
-    }, hasPassive ? {passive: false} : false)
+    }, hasPassive ? {passive: true} : false)
 
     element.addEventListener('touchmove', function (ev) {
       var xy = mouseOffset(ev.changedTouches[0], element)
       handleInteraction(1, xy[0], xy[1], camera._lastMods)
-
       ev.preventDefault()
     }, hasPassive ? {passive: false} : false)
 
     element.addEventListener('touchend', function (ev) {
-
       handleInteraction(0, camera._lastX, camera._lastY, camera._lastMods)
-
-      ev.preventDefault()
-    }, hasPassive ? {passive: false} : false)
+    }, hasPassive ? {passive: true} : false)
 
     function handleInteraction (buttons, x, y, mods) {
       var keyBindingMode = camera.keyBindingMode


### PR DESCRIPTION
Related to: https://github.com/plotly/plotly.js/issues/4550 
Looks to fix interactivity in 3d plots on mobile and tablet devices. 
I'm not sure what the best way is to test this and that it doesn't break anything else. But I did test by making these changes on the plotly.js repo at a commit that was before camera.js was moved to this repo. 